### PR TITLE
Notification email: send event parameters to template

### DIFF
--- a/lib/plugins/mail.js
+++ b/lib/plugins/mail.js
@@ -102,6 +102,23 @@ function sendNotificationEmail(server) {
 
     const managementUrl = `https://${network}.aragon.org/#/${ensName}/?preferences=/notifications`
 
+    // Converts a camelcase key to a friendlier format
+    // Example: voteId -> Vote Id
+    const convertKey = key =>
+      key
+        .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1 $2')
+        .toLowerCase()
+        .replace(/\b\w/g, firstChar => firstChar.toUpperCase())
+
+    // Processes event return values. Example:
+    // Input: {"0":"1","1":"0x0596598561d0C8ECEAd2b3E836e90298b4Ed012A","voteId":"1","creator":"0x0596598561d0C8ECEAd2b3E836e90298b4Ed012A"}
+    // Output: [ { parameter: 'Vote Id', value: '1' }, { parameter: 'Creator', value: '0x0596598561d0C8ECEAd2b3E836e90298b4Ed012A' } ]
+    const prepareEventParameters = eventValues =>
+      Object.keys(eventValues)
+        .filter(key => isNaN(key)) // filter out number keys
+        .reduce((params, key) => [...params, { parameter: convertKey(key), value: eventValues[key] }], [])
+
     const emailOptions = {
       From: ARAGON_FROM_ADDRESS,
       To: email,
@@ -113,6 +130,7 @@ function sendNotificationEmail(server) {
         contractAddress,
         eventName,
         eventValues: JSON.stringify(returnValues, null, 2),
+        eventParameters: prepareEventParameters(returnValues),
         etherscanUrl,
         managementUrl,
         network,


### PR DESCRIPTION
By parsing and sending event parameters, we can avoid showing the JSON representation of the event return values.

Converting this:
<img width="412" alt=" 2019-09-10 at 3 47 44 PM" src="https://user-images.githubusercontent.com/447328/64624294-598d1a80-d3e2-11e9-9620-cd8962f52440.png">

Into this:
<img width="549" alt=" 2019-09-10 at 3 45 43 PM" src="https://user-images.githubusercontent.com/447328/64624300-5e51ce80-d3e2-11e9-9e4b-fe1edcab4f8e.png">

Note: I have been testing it on a [duplicate of the notification template](https://account.postmarkapp.com/servers/3291503/templates/13635813/edit) and we could change the actual template once this is deployed.