### PR TITLE
Implement court dashboard registration endpoint

### DIFF
--- a/lib/plugins/court.js
+++ b/lib/plugins/court.js
@@ -1,0 +1,58 @@
+import Joi from '@hapi/joi'
+import Boom from '@hapi/boom'
+
+const court = {
+  name: 'ns/court',
+  version: '1.0.0',
+  register: async function(server, options) {
+    server.dependency(['ns/web3', 'ns/database', 'ns/mail'])
+
+    server.route(routes)
+  },
+}
+
+export default court
+
+const routes = [
+  {
+    method: 'POST',
+    path: '/create',
+    handler: createHandler,
+    options: {
+      tags: ['api'],
+      auth: false,
+      validate: {
+        failAction: (request, h, err) => {
+          // show validation errors to user https://github.com/hapijs/hapi/issues/3706
+          throw err
+        },
+        payload: {
+          network: Joi.string().required(),
+          address: Joi.string().required(),
+          email: Joi.string()
+            .email()
+            .required(),
+        },
+      },
+    },
+  },
+]
+
+/**
+ * Registration handler
+ */
+async function createHandler(request, h) {
+  const { db } = request.server.app
+  const { email, address, network } = request.payload
+
+  try {
+    await db('court_users')
+      .insert({ network, email, address })
+      .returning('user_id')
+      .then(([id]) => id)
+
+    return h.response().code(200)
+  } catch (error) {
+    return Boom.badImplementation(error.message)
+  }
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ import mail from './plugins/mail'
 import metrics from './plugins/metrics'
 import subscriptions from './plugins/subscriptions'
 import account from './plugins/account'
+import court from './plugins/court'
 import web3 from './plugins/web3'
 
 import {
@@ -87,6 +88,7 @@ const init = async () => {
     mail,
     subscriptions,
     account,
+    court,
     notificationScanner,
     notificationMailer,
   ])

--- a/migrations/20191218180145_create_court_users.js
+++ b/migrations/20191218180145_create_court_users.js
@@ -1,0 +1,18 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('court_users', function(table) {
+    table
+      .increments('user_id')
+      .unsigned()
+      .primary()
+
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+
+    table.string('address').notNullable()
+    table.string('network').notNullable()
+    table.string('email').notNullable()
+  })
+}
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('court_users')
+}


### PR DESCRIPTION
I added a simple endpoint to store the information coming from the ANJ buying module of the jurors microsite. For reference:

![image](https://user-images.githubusercontent.com/6967192/71113498-776dd680-21ac-11ea-82fa-de504d6383d1.png)

As you can see I'm storing any entry it comes in, no validations. Users could buy ANJ inserting different email addresses or using different Ethereum accounts for the same email address. We will figure out how to normalize all this information later. We will probably set up a separate notification service for the dashboard.