### PR TITLE
Remove now.sh from allowed cors policy

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -28,10 +28,7 @@ const server = Hapi.server({
   host: process.env.HOST,
   routes: {
     cors: {
-      origin:
-        process.env.NODE_ENV === 'production'
-          ? ['*.aragon.org', '*.now.sh']
-          : ['*'],
+      origin: process.env.NODE_ENV === 'production' ? ['*.aragon.org'] : ['*'],
       headers: ['authorization', 'Content-Type'], // allow the client to send these
       exposedHeaders: ['authorization'], // give cross origins access to response authorization header
       credentials: true, // Access-Control-Allow-Credentials - allow passing authorization header cross origin


### PR DESCRIPTION
For development builds we should change the notification service URL to a non-production environment.